### PR TITLE
Add more cases for resolver (utils)

### DIFF
--- a/addon/ember-config.js
+++ b/addon/ember-config.js
@@ -26,6 +26,9 @@ export default {
     transform: { definitiveCollection: 'transforms' },
     util: { definitiveCollection: 'utils' }
   },
+  unresolvableCollections: {
+    utils: false
+  },
   collections: {
     components: {
       group: 'ui',
@@ -58,9 +61,6 @@ export default {
     transforms: {
       group: 'data',
       types: ['transform']
-    },
-    utils: {
-      resolvable: false
     }
   }
 };

--- a/addon/ember-config.js
+++ b/addon/ember-config.js
@@ -1,0 +1,66 @@
+/*
+ * This config describes canonical Ember, as described in the
+ * module unification spec:
+ *
+ *   https://github.com/dgeb/rfcs/blob/module-unification/text/0000-module-unification.md
+ *
+ */
+export default {
+  types: {
+    adapter: { definitiveCollection: 'models' },
+    controller: { definitiveCollection: 'routes' },
+    component: { definitiveCollection: 'components' },
+    initializer: { definitiveCollection: 'initializers' },
+    'instance-initializers': { definitiveCollection: 'instance-initializer' },
+    model: { definitiveCollection: 'models' },
+    partial: { definitiveCollection: 'partials' },
+    route: { definitiveCollection: 'routes' },
+    serializer: { definitiveCollection: 'models' },
+    service: { definitiveCollection: 'services' },
+    template: {
+      definitiveCollection: 'routes',
+      fallbackCollectionPrefixes: {
+        'components/': 'components'
+      }
+    },
+    transform: { definitiveCollection: 'transforms' },
+    util: { definitiveCollection: 'utils' }
+  },
+  collections: {
+    components: {
+      group: 'ui',
+      types: ['component', 'helper', 'template']
+    },
+    initializers: {
+      group: 'init',
+      types: ['initializer']
+    },
+    'instance-initializers': {
+      group: 'init',
+      types: ['instance-initializers']
+    },
+    models: {
+      group: 'data',
+      types: ['model', 'adapter', 'serializer']
+    },
+    partials: {
+      group: 'ui',
+      types: ['partial']
+    },
+    routes: {
+      group: 'ui',
+      privateCollections: ['components'],
+      types: ['route', 'controller', 'template']
+    },
+    services: {
+      types: ['service']
+    },
+    transforms: {
+      group: 'data',
+      types: ['transform']
+    },
+    utils: {
+      resolvable: false
+    }
+  }
+};

--- a/addon/unified-resolver.js
+++ b/addon/unified-resolver.js
@@ -80,12 +80,15 @@ const Resolver = DefaultResolver.extend({
         }
         collection = alternativeCollections[0];
         group = this.config.collections[collection].group;
-      } else if (this.config.collections[privateCollection].resolvable === false) {
-        // Configuring a collection to be { resolvable: false } stops that
-        // collection from being resolved at the top level. It also means that
-        // the collection cannot be used as a private collection regardless of
-        // whether it is listed explicitly as a private collection.
-        throw new Error(`attempted to resolve a module in the unresolvable collection "${privateCollection}"`);
+      } else {
+        let { unresolvableCollections } = this.config;
+        if (unresolvableCollections && unresolvableCollections[privateCollection]) {
+          // Configuring a collection to be { resolvable: false } stops that
+          // collection from being resolved at the top level. It also means that
+          // the collection cannot be used as a private collection regardless of
+          // whether it is listed explicitly as a private collection.
+          throw new Error(`attempted to resolve a module in the unresolvable collection "${privateCollection}"`);
+        }
       }
     } else if (parts.length > 2) {
       throw new Error('Non-ambiguous, but painful to parse case');

--- a/addon/unified-resolver.js
+++ b/addon/unified-resolver.js
@@ -59,9 +59,11 @@ const Resolver = DefaultResolver.extend({
     }
 
     let parts = name.split('/-');
+
+    // If we have a private collection
     if (parts.length === 2) {
-      // We have a private collection
       let privateCollection = parts[1].split('/')[0];
+
       if (collection === privateCollection) {
         // The proposed source collection cannot be correct, since the
         // private collection is the same. A private collection cannot be
@@ -78,6 +80,12 @@ const Resolver = DefaultResolver.extend({
         }
         collection = alternativeCollections[0];
         group = this.config.collections[collection].group;
+      } else if (this.config.collections[privateCollection].resolvable === false) {
+        // Configuring a collection to be { resolvable: false } stops that
+        // collection from being resolved at the top level. It also means that
+        // the collection cannot be used as a private collection regardless of
+        // whether it is listed explicitly as a private collection.
+        throw new Error(`attempted to resolve a module in the unresolvable collection "${privateCollection}"`);
       }
     } else if (parts.length > 2) {
       throw new Error('Non-ambiguous, but painful to parse case');

--- a/addon/unified-resolver.js
+++ b/addon/unified-resolver.js
@@ -14,14 +14,11 @@ const Resolver = DefaultResolver.extend({
 
   expandLocalLookup(lookupString, sourceLookupString, options) {
     let { type, name } = this._parseLookupString(lookupString);
-    let { collection: sourceCollection, name: sourceName } = this._parseLookupString(sourceLookupString);
+    let source = this._parseLookupString(sourceLookupString);
+    let sourceCollectionConfig = this.config.collections[source.collection];
 
-    let expandedLookupString;
-    // theTypeOfTheLookupIsNotValidInTheFinalCollectionOfTheSource
-    // so here sourceCollection is expected to be the private collection, if
-    // present
-    let sourceCollectionConfig = this.config.collections[sourceCollection];
     // Perhaps should blow up if you are not in the types, TODO bad error state in here
+    let expandedLookupString;
     if (sourceCollectionConfig.types.indexOf(type) === -1 && sourceCollectionConfig.privateCollections) {
       let privateCollection;
       sourceCollectionConfig.privateCollections.forEach(key => {
@@ -29,14 +26,14 @@ const Resolver = DefaultResolver.extend({
         // If the lookup type is permitted in this specific private collection
         if (privateCollectionConfig.types.indexOf(type) !== -1) {
           if (privateCollection) {
-            throw new Error(`More than one private collection supporting type "${type}" was available in collection ${sourceCollection}`);
+            throw new Error(`More than one private collection supporting type "${type}" was available in collection ${source.collection}`);
           }
           privateCollection = key;
         }
       });
-      expandedLookupString = `${type}:${sourceName}/-${privateCollection}/${name}`;
+      expandedLookupString = `${type}:${source.name}/-${privateCollection}/${name}`;
     } else {
-      expandedLookupString = `${type}:${sourceName}/${name}`;
+      expandedLookupString = `${type}:${source.name}/${name}`;
     }
 
     let { name: moduleName, exportName } = this._resolveLookupStringToModuleName(expandedLookupString, options);

--- a/tests/unit/unified-resolver/basic-dynamic-test.js
+++ b/tests/unit/unified-resolver/basic-dynamic-test.js
@@ -488,10 +488,10 @@ expectResolutions({
     types: {
       service: { definitiveCollection: 'services' }
     },
+    unresolvableCollections: {
+      utils: true
+    },
     collections: {
-      utils: {
-        resolvable: false
-      },
       services: {
         types: ['service']
       }

--- a/tests/unit/unified-resolver/basic-dynamic-test.js
+++ b/tests/unit/unified-resolver/basic-dynamic-test.js
@@ -481,6 +481,29 @@ expectResolutions({
   }
 });
 
+expectResolutions({
+  message: 'Unresolvable collections (utils)',
+  namespace,
+  config: {
+    types: {
+      service: { definitiveCollection: 'services' }
+    },
+    collections: {
+      utils: {
+        resolvable: false
+      },
+      services: {
+        types: ['service']
+      }
+    }
+  },
+  moduleOverrides: {},
+  errors: {
+    'util:my-util': /"util" not a recognized type/,
+    'service:services/-utils/my-service': /attempted to resolve a module in the unresolvable collection "utils"/
+  }
+});
+
 /*
 to do:
  * figure out the signature for instantiating the resolver -- what is it now, and where does the new config stuff go in?

--- a/tests/unit/unified-resolver/basic-dynamic-test.js
+++ b/tests/unit/unified-resolver/basic-dynamic-test.js
@@ -507,15 +507,9 @@ expectResolutions({
 /*
 to do:
  * figure out the signature for instantiating the resolver -- what is it now, and where does the new config stuff go in?
- * figure out the structure of the config
  * the tests in resolver-test.js should be made to work simply by making the new resolver fallback to delegating to the old resolver
  *   ^^^ mixonic thinks this is incorrect. You should opt-in to the new resolver.
  *   Or perhaps only if you have a src dir?
- * Tests that show you cannot resolve anything from the utils directory, per spec
- * Tests that do private collections. Will involve respecting the `source` (I
- *   think) argument to the resolve method.
- * We need a word for `app` vs `src` (right now we call it namespace which is already used in the spec).
-
 
  ember-cli/loader.js  open issue, public API for require/define    can import from loader instead of global requirejs https://github.com/ember-cli/loader.js/issues/82
  (bug) we don't fallback to index (like node does)

--- a/tests/unit/unified-resolver/expand-local-lookup-test.js
+++ b/tests/unit/unified-resolver/expand-local-lookup-test.js
@@ -209,8 +209,38 @@ test('expandLocalLookup expands to a private collection', function(assert) {
   assert.strictEqual(factoryName, 'helper:my-route/-components/my-helper', '-component namespace included in lookup');
 });
 
+test('expandLocalLookup returns null when no module exists in a private collection', function(assert) {
+  assert.expect(1);
 
-/*
-test('expandLocalLookup returns null when no module exists in a private collection', function(asset) {
+  let fakeRegistry = new FakeRegistry({});
+
+  let resolver = Resolver.create({
+    _moduleRegistry: fakeRegistry,
+    config: {
+      types: {
+        template: {
+          definitiveCollection: 'routes',
+          fallbackCollectionPrefixes: {
+            'components/': 'components'
+          }
+        },
+        helper: { definitiveCollection: 'components' }
+      },
+      collections: {
+        routes: {
+          group: 'ui',
+          types: ['template'],
+          privateCollections: ['components']
+        },
+        components: {
+          group: 'ui',
+          types: ['helper']
+        }
+      }
+    }
+  });
+
+  let factoryName = resolver.expandLocalLookup('helper:my-helper', 'template:my-route', {namespace: this.namespace});
+
+  assert.strictEqual(factoryName, null, '-component namespace included in lookup');
 });
-*/


### PR DESCRIPTION
@bantic @iezer Mat and I worked through the rest of our known cases for the resolver and created a `config` object that represents the types and collections in Ember. 
