### PR TITLE
Align the namespace/modulePrefix with Ember

### DIFF
--- a/addon/unified-resolver.js
+++ b/addon/unified-resolver.js
@@ -7,12 +7,13 @@ const Resolver = DefaultResolver.extend({
   init() {
     this._super(...arguments);
 
+    this._modulePrefix = `${this.namespace.modulePrefix}/src`;
     if (!this._moduleRegistry) {
       this._moduleRegistry = new ModuleRegistry();
     }
   },
 
-  expandLocalLookup(lookupString, sourceLookupString, options) {
+  expandLocalLookup(lookupString, sourceLookupString) {
     let { type, name } = this._parseLookupString(lookupString);
     let source = this._parseLookupString(sourceLookupString);
     let sourceCollectionConfig = this.config.collections[source.collection];
@@ -36,7 +37,7 @@ const Resolver = DefaultResolver.extend({
       expandedLookupString = `${type}:${source.name}/${name}`;
     }
 
-    let { name: moduleName, exportName } = this._resolveLookupStringToModuleName(expandedLookupString, options);
+    let { name: moduleName, exportName } = this._resolveLookupStringToModuleName(expandedLookupString);
 
     if (this._moduleRegistry.has(moduleName) && this._moduleRegistry.get(moduleName, exportName)) {
       return expandedLookupString;
@@ -45,13 +46,13 @@ const Resolver = DefaultResolver.extend({
     return null;
   },
 
-  _resolveLookupStringToModuleName(lookupString, options) {
+  _resolveLookupStringToModuleName(lookupString) {
     let { type, collection, group, isDefaultType, name } = this._parseLookupString(lookupString);
 
     // Main factories have no collection
     if (name === 'main') {
       // throw if the collection is not ''
-      let path = `${options.namespace}/${type}`;
+      let path = `${this._modulePrefix}/${type}`;
       if (this._moduleRegistry.has(path)) {
         return {name: path, exportName: 'default'};
       }
@@ -96,7 +97,7 @@ const Resolver = DefaultResolver.extend({
 
     // Other factories have a collection
     let groupSegment = group ? `${group}/` : '';
-    let namePath = `${options.namespace}/${groupSegment}${collection}/${name}`;
+    let namePath = `${this._modulePrefix}/${groupSegment}${collection}/${name}`;
 
     let path = `${namePath}/${type}`;
     if (this._moduleRegistry.has(path)) {
@@ -111,8 +112,8 @@ const Resolver = DefaultResolver.extend({
   },
 
   // this returns the actual module
-  resolve(lookupString, options) {
-    let { name, exportName } = this._resolveLookupStringToModuleName(lookupString, options);
+  resolve(lookupString) {
+    let { name, exportName } = this._resolveLookupStringToModuleName(lookupString);
     return this._moduleRegistry.get(name, exportName);
   },
 

--- a/tests/unit/unified-resolver/expand-local-lookup-test.js
+++ b/tests/unit/unified-resolver/expand-local-lookup-test.js
@@ -1,10 +1,9 @@
 import { module, test } from 'qunit';
 import Resolver from 'ember-resolver/unified-resolver';
 
+let modulePrefix = 'test-prefix';
+
 module('ember-resolver/unified-resolver #expandLocalLookup', {
-  beforeEach() {
-    this.namespace = 'test-namespace';
-  }
 });
 
 class FakeRegistry {
@@ -32,10 +31,11 @@ test('expandLocalLookup expands to a namespace when the source is in a collectio
 
   let expectedObject = {};
   let fakeRegistry = new FakeRegistry({
-    [`${this.namespace}/ui/components/my-form/my-input/component`]: { default: expectedObject }
+    [`${modulePrefix}/src/ui/components/my-form/my-input/component`]: { default: expectedObject }
   });
 
   let resolver = Resolver.create({
+    namespace: {modulePrefix},
     _moduleRegistry: fakeRegistry,
     config: {
       types: {
@@ -50,7 +50,7 @@ test('expandLocalLookup expands to a namespace when the source is in a collectio
     }
   });
 
-  let factoryName = resolver.expandLocalLookup('component:my-input', 'component:my-form', {namespace: this.namespace});
+  let factoryName = resolver.expandLocalLookup('component:my-input', 'component:my-form');
 
   assert.strictEqual(factoryName, 'component:my-form/my-input', 'returns a module namespace of "my-form"');
 });
@@ -60,10 +60,11 @@ test('expandLocalLookup expands to a namespace when the source is in a collectio
 
   let expectedObject = {};
   let fakeRegistry = new FakeRegistry({
-    [`${this.namespace}/ui/components/my-form/my-input`]: { default: expectedObject }
+    [`${modulePrefix}/src/ui/components/my-form/my-input`]: { default: expectedObject }
   });
 
   let resolver = Resolver.create({
+    namespace: {modulePrefix},
     _moduleRegistry: fakeRegistry,
     config: {
       types: {
@@ -79,7 +80,7 @@ test('expandLocalLookup expands to a namespace when the source is in a collectio
     }
   });
 
-  let factoryName = resolver.expandLocalLookup('component:my-input', 'component:my-form', {namespace: this.namespace});
+  let factoryName = resolver.expandLocalLookup('component:my-input', 'component:my-form');
 
   assert.strictEqual(factoryName, 'component:my-form/my-input', 'returns a module namespace of "my-form"');
 });
@@ -89,10 +90,11 @@ test('expandLocalLookup expands to a namespace when the source is in a collectio
 
   let expectedObject = {};
   let fakeRegistry = new FakeRegistry({
-    [`${this.namespace}/ui/components/my-form/my-input`]: { component: expectedObject }
+    [`${modulePrefix}/src/ui/components/my-form/my-input`]: { component: expectedObject }
   });
 
   let resolver = Resolver.create({
+    namespace: {modulePrefix},
     _moduleRegistry: fakeRegistry,
     config: {
       types: {
@@ -107,7 +109,7 @@ test('expandLocalLookup expands to a namespace when the source is in a collectio
     }
   });
 
-  let factoryName = resolver.expandLocalLookup('component:my-input', 'component:my-form', {namespace: this.namespace});
+  let factoryName = resolver.expandLocalLookup('component:my-input', 'component:my-form');
 
   assert.strictEqual(factoryName, 'component:my-form/my-input', 'returns a module namespace of "my-form"');
 });
@@ -119,6 +121,7 @@ test('expandLocalLookup returns null when no module exists in a namespaces looku
   });
 
   let resolver = Resolver.create({
+    namespace: {modulePrefix},
     _moduleRegistry: fakeRegistry,
     config: {
       types: {
@@ -133,7 +136,7 @@ test('expandLocalLookup returns null when no module exists in a namespaces looku
     }
   });
 
-  let factoryName = resolver.expandLocalLookup('component:my-input', 'component:my-form', {namespace: this.namespace});
+  let factoryName = resolver.expandLocalLookup('component:my-input', 'component:my-form');
 
   assert.strictEqual(factoryName, null, 'returns null when there is no local lookup module');
 });
@@ -142,10 +145,11 @@ test('expandLocalLookup expands to a namespace when the source is in a private c
   assert.expect(1);
 
   let fakeRegistry = new FakeRegistry({
-    [`${this.namespace}/ui/routes/my-route/-components/my-component/my-helper/helper`]: { default: {} }
+    [`${modulePrefix}/src/ui/routes/my-route/-components/my-component/my-helper/helper`]: { default: {} }
   });
 
   let resolver = Resolver.create({
+    namespace: {modulePrefix},
     _moduleRegistry: fakeRegistry,
     config: {
       types: {
@@ -166,7 +170,7 @@ test('expandLocalLookup expands to a namespace when the source is in a private c
     }
   });
 
-  let factoryName = resolver.expandLocalLookup('helper:my-helper', 'component:my-route/-components/my-component', {namespace: this.namespace});
+  let factoryName = resolver.expandLocalLookup('helper:my-helper', 'component:my-route/-components/my-component');
 
   assert.strictEqual(factoryName, 'helper:my-route/-components/my-component/my-helper', '-component namespace included in lookup');
 });
@@ -175,10 +179,11 @@ test('expandLocalLookup expands to a private collection', function(assert) {
   assert.expect(1);
 
   let fakeRegistry = new FakeRegistry({
-    [`${this.namespace}/ui/routes/my-route/-components/my-helper/helper`]: { default: {} }
+    [`${modulePrefix}/src/ui/routes/my-route/-components/my-helper/helper`]: { default: {} }
   });
 
   let resolver = Resolver.create({
+    namespace: {modulePrefix},
     _moduleRegistry: fakeRegistry,
     config: {
       types: {
@@ -204,7 +209,7 @@ test('expandLocalLookup expands to a private collection', function(assert) {
     }
   });
 
-  let factoryName = resolver.expandLocalLookup('helper:my-helper', 'template:my-route', {namespace: this.namespace});
+  let factoryName = resolver.expandLocalLookup('helper:my-helper', 'template:my-route');
 
   assert.strictEqual(factoryName, 'helper:my-route/-components/my-helper', '-component namespace included in lookup');
 });
@@ -215,6 +220,7 @@ test('expandLocalLookup returns null when no module exists in a private collecti
   let fakeRegistry = new FakeRegistry({});
 
   let resolver = Resolver.create({
+    namespace: {modulePrefix},
     _moduleRegistry: fakeRegistry,
     config: {
       types: {
@@ -240,7 +246,7 @@ test('expandLocalLookup returns null when no module exists in a private collecti
     }
   });
 
-  let factoryName = resolver.expandLocalLookup('helper:my-helper', 'template:my-route', {namespace: this.namespace});
+  let factoryName = resolver.expandLocalLookup('helper:my-helper', 'template:my-route');
 
   assert.strictEqual(factoryName, null, '-component namespace included in lookup');
 });


### PR DESCRIPTION
The module spec specifies that modules will be passed to the browser
with the app name and `src` directory in the path. For example:

  test-app/src/ui/components/phone-book.js

This commit aligns the resolver with the spec.

See:
https://github.com/dgeb/rfcs/blob/module-unification/text/0000-module-unification.md#es-modules
