### PR TITLE
Export unified resolver

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,1 +1,1 @@
-export { default } from './resolver';
+export { default } from './unified-resolver';

--- a/addon/unified-resolver.js
+++ b/addon/unified-resolver.js
@@ -1,11 +1,16 @@
 import Ember from 'ember';
 import ModuleRegistry from './utils/module-registry';
+import DefaultConfig from './ember-config';
 
 const { DefaultResolver } = Ember;
 
 const Resolver = DefaultResolver.extend({
   init() {
     this._super(...arguments);
+
+    if (!this.config) {
+      this.config = DefaultConfig;
+    }
 
     this._modulePrefix = `${this.namespace.modulePrefix}/src`;
     if (!this._moduleRegistry) {

--- a/addon/unified-resolver.js
+++ b/addon/unified-resolver.js
@@ -121,7 +121,10 @@ const Resolver = DefaultResolver.extend({
   resolve(lookupString) {
     let moduleDef = this._resolveLookupStringToModuleName(lookupString);
     if (moduleDef && this._moduleRegistry.has(moduleDef.name)) {
+      console.log('resolve: ' + lookupString + ' √');
       return this._moduleRegistry.get(moduleDef.name, moduleDef.exportName);
+    } else {
+      console.log('resolve: ' + lookupString + ' []');
     }
   },
 

--- a/app/initializers/container-debug-adapter.js
+++ b/app/initializers/container-debug-adapter.js
@@ -1,4 +1,4 @@
-import ContainerDebugAdapter from 'ember-resolver/container-debug-adapter';
+import ContainerDebugAdapter from 'dangerously-set-unified-resolver/container-debug-adapter';
 
 export default {
   name: 'container-debug-adapter',

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 var VersionChecker = require('ember-cli-version-checker');
 
 module.exports = {
-  name: 'ember-resolver',
+  name: 'dangerously-set-unified-resolver',
 
   isDevelopingAddon: function() {
     return true


### PR DESCRIPTION
- change the other references to "ember-resolver" to "dangerously-set-unified-resolver"
- log `resolve` calls (and whether they found anything)
- use the `ember-config` by default if no `config` is passed when creating the resolver
