### PR TITLE
fix normalization for things with 2 words

### DIFF
--- a/tests/unit/unified-resolver/normalize-test.js
+++ b/tests/unit/unified-resolver/normalize-test.js
@@ -1,0 +1,20 @@
+import { module, test } from 'qunit';
+import Resolver from 'ember-resolver/unified-resolver';
+
+let modulePrefix = 'test-namespace';
+
+module('ember-resolver/unified-resolver #normalize', {});
+
+test('normalize components/my-input', function(assert) {
+  let resolver = Resolver.create({
+    namespace: {modulePrefix}
+  });
+  assert.equal(resolver.normalize('component:my-input'), 'component:my-input', 'normalize preserves dasherization for component:my-input');
+});
+
+test('normalize route:my-input', function(assert) {
+  let resolver = Resolver.create({
+    namespace: {modulePrefix}
+  });
+  assert.equal(resolver.normalize('route:my-input'), 'route:my-input', 'normalize preserves dasherization for route:my-input');
+})


### PR DESCRIPTION
Fixes normalization for JS files with a dash. DefaultResolver behavior is to change
- `route:happy-people` -> `route:happyPeople`
- `component:my-input` -> `component:myInput`

And the original `resolver.js` in ember-resolver has some simpler behavior to dasherize everything. This copies that behavior to the new resolver and adds tests that would fail without it.
