### PR TITLE
Add treeForApp hook to mv src/ to app/src/

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,14 @@
 'use strict';
 
 var VersionChecker = require('ember-cli-version-checker');
+var Funnel = require('broccoli-funnel');
+var MergeTrees = require('broccoli-merge-trees')
+
+var renameMap = {
+  'src/main.js': 'app.js',
+  'src/resolver.js': 'resolver.js',
+  'src/ui/styles/app.css': 'styles/app.css' // Need a glob strategy
+};
 
 module.exports = {
   name: 'dangerously-set-unified-resolver',
@@ -21,6 +29,24 @@ module.exports = {
     }
 
     this.app.import('vendor/ember-resolver/legacy-shims.js');
+  },
+
+  treeForApp() {
+    var srcTree = new Funnel('src', {
+      destDir: 'src'
+    });
+
+    var appTree = new Funnel('app');
+
+    var unifiedTree = new MergeTrees([appTree, srcTree]);
+
+    var withAppCompatibility = new Funnel(unifiedTree, {
+      getDestinationPath: function getDestinationPath(relativePath) {
+        return renameMap[relativePath] || relativePath;
+      }
+    });
+
+    return withAppCompatibility;
   },
 
   monkeyPatchVendorFiles: function() {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
-    "ember-cli-version-checker": "^1.1.6"
+    "ember-cli-version-checker": "^1.1.6",
+    "broccoli-funnel": "^1.0.7",
+    "broccoli-merge-trees": "^1.1.4"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
brings in the stuff that used to be in the app's in-repo-addon
