### PR TITLE
fix tests

### DIFF
--- a/addon/unified-resolver.js
+++ b/addon/unified-resolver.js
@@ -59,7 +59,7 @@ const Resolver = DefaultResolver.extend({
 
     let { name: moduleName, exportName } = this._resolveLookupStringToModuleName(expandedLookupString);
 
-    if (this._moduleRegistry.has(moduleName) && this._moduleRegistry.get(moduleName, exportName)) {
+    if (this._moduleRegistry.has(moduleName) && this._moduleRegistry.getExport(moduleName, exportName)) {
       return expandedLookupString;
     }
 
@@ -136,7 +136,7 @@ const Resolver = DefaultResolver.extend({
   resolve(lookupString) {
     let moduleDef = this._resolveLookupStringToModuleName(lookupString);
     if (moduleDef && this._moduleRegistry.has(moduleDef.name)) {
-      return this._moduleRegistry.get(moduleDef.name, moduleDef.exportName);
+      return this._moduleRegistry.getExport(moduleDef.name, moduleDef.exportName);
     }
   },
 

--- a/addon/utils/module-registry.js
+++ b/addon/utils/module-registry.js
@@ -18,7 +18,11 @@ ModuleRegistry.prototype.has = function ModuleRegistry_has(moduleName) {
   return moduleName in this._entries;
 };
 
-ModuleRegistry.prototype.get = function ModuleRegistry_get(moduleName, exportName = 'default') {
+ModuleRegistry.prototype.get = function ModuleRegistry_get(moduleName) {
+  return require(moduleName);
+};
+
+ModuleRegistry.prototype.getExport = function ModuleRegistry_get_export(moduleName, exportName = 'default') {
   let module = require(moduleName);
   if (exportName) {
     return module && module[exportName];

--- a/tests/unit/unified-resolver/basic-dynamic-test.js
+++ b/tests/unit/unified-resolver/basic-dynamic-test.js
@@ -12,7 +12,7 @@ class NewFakeRegistry {
     this._moduleOverrides = moduleOverrides || {};
   }
 
-  get(moduleName, exportName = 'default') {
+  getExport(moduleName, exportName = 'default') {
     if (Object.keys(this._moduleOverrides).indexOf(moduleName) !== -1) {
       let result = this._moduleOverrides[moduleName];
       if (!result) {

--- a/tests/unit/unified-resolver/expand-local-lookup-test.js
+++ b/tests/unit/unified-resolver/expand-local-lookup-test.js
@@ -12,7 +12,7 @@ class FakeRegistry {
     this._get = [];
   }
 
-  get(moduleName) {
+  getExport(moduleName) {
     this._get.push(moduleName);
     let module = this._entries[moduleName];
     if (module) {


### PR DESCRIPTION
preserve old moduleRegistry.get behavior and make new function getExport for unified-resolver.
