### PR TITLE
WIP: Test fallback functionality

### DIFF
--- a/addon/dynamic-resolver.js
+++ b/addon/dynamic-resolver.js
@@ -1,0 +1,178 @@
+import Ember from 'ember';
+import ModuleRegistry from './utils/module-registry';
+import makeDictionary from './utils/make-dictionary';
+
+const { DefaultResolver } = Ember;
+
+const Resolver = DefaultResolver.extend({
+  init() {
+    this._super(...arguments);
+
+    this._modulePrefix = `${this.namespace.modulePrefix}/src`;
+    if (!this._moduleRegistry) {
+      this._moduleRegistry = new ModuleRegistry();
+    }
+
+    this._normalizeCache = makeDictionary();
+  },
+
+  normalize: function(fullName) {
+    return this._normalizeCache[fullName] || (this._normalizeCache[fullName] = this._normalize(fullName));
+  },
+
+  _normalize: function(fullName) {
+    // replace `.` with `/` in order to make nested controllers work in the following cases
+    // 1. `needs: ['posts/post']`
+    // 2. `{{render "posts/post"}}`
+    // 3. `this.render('posts/post')` from Route
+    var split = fullName.split(':');
+    if (split.length > 1) {
+      return split[0] + ':' + Ember.String.dasherize(split[1].replace(/\./g, '/'));
+    } else {
+      return fullName;
+    }
+  },
+
+  expandLocalLookup(lookupString, sourceLookupString) {
+    let { type, name } = this._parseLookupString(lookupString);
+    let source = this._parseLookupString(sourceLookupString);
+    let sourceCollectionConfig = this.config.collections[source.collection];
+
+    // Perhaps should blow up if you are not in the types, TODO bad error state in here
+    let expandedLookupString;
+    if (sourceCollectionConfig.types.indexOf(type) === -1 && sourceCollectionConfig.privateCollections) {
+      let privateCollection;
+      sourceCollectionConfig.privateCollections.forEach(key => {
+        let privateCollectionConfig = this.config.collections[key];
+        // If the lookup type is permitted in this specific private collection
+        if (privateCollectionConfig.types.indexOf(type) !== -1) {
+          if (privateCollection) {
+            throw new Error(`More than one private collection supporting type "${type}" was available in collection ${source.collection}`);
+          }
+          privateCollection = key;
+        }
+      });
+      expandedLookupString = `${type}:${source.name}/-${privateCollection}/${name}`;
+    } else {
+      expandedLookupString = `${type}:${source.name}/${name}`;
+    }
+
+    let { name: moduleName, exportName } = this._resolveLookupStringToModuleName(expandedLookupString);
+
+    if (this._moduleRegistry.has(moduleName) && this._moduleRegistry.getExport(moduleName, exportName)) {
+      return expandedLookupString;
+    }
+
+    return null;
+  },
+
+  _resolveLookupStringToModuleName(lookupString) {
+    let { type, collection, group, isDefaultType, name } = this._parseLookupString(lookupString);
+
+    // Main factories have no collection
+    if (name === 'main') {
+      // throw if the collection is not ''
+      let path = `${this._modulePrefix}/${type}`;
+      if (this._moduleRegistry.has(path)) {
+        return {name: path, exportName: 'default'};
+      }
+      return null;
+      // throw new Error(`Could not resolve factory '${lookupString}' at path '${path}'`);
+    }
+
+    let parts = name.split('/-');
+
+    // If we have a private collection
+    if (parts.length === 2) {
+      let privateCollection = parts[1].split('/')[0];
+
+      if (collection === privateCollection) {
+        // The proposed source collection cannot be correct, since the
+        // private collection is the same. A private collection cannot be
+        // in itself. For example: src/ui/component/phone-book/-components/
+        let alternativeCollections = [];
+        Object.keys(this.config.collections).filter(collection => {
+          let collectionDef = this.config.collections[collection];
+          if (collectionDef.privateCollections && collectionDef.privateCollections.indexOf(privateCollection) !== -1) {
+            alternativeCollections.push(collection);
+          }
+        });
+        if (alternativeCollections.length > 1) {
+          throw new Error('a private collection should not be configured for more than one collection');
+        }
+        collection = alternativeCollections[0];
+        group = this.config.collections[collection].group;
+      } else {
+        let { unresolvableCollections } = this.config;
+        if (unresolvableCollections && unresolvableCollections[privateCollection]) {
+          // Configuring a collection to be { resolvable: false } stops that
+          // collection from being resolved at the top level. It also means that
+          // the collection cannot be used as a private collection regardless of
+          // whether it is listed explicitly as a private collection.
+          throw new Error(`attempted to resolve a module in the unresolvable collection "${privateCollection}"`);
+        }
+      }
+    } else if (parts.length > 2) {
+      throw new Error('Non-ambiguous, but painful to parse case');
+    }
+
+    // Other factories have a collection
+    let groupSegment = group ? `${group}/` : '';
+    let namePath = `${this._modulePrefix}/${groupSegment}${collection}/${name}`;
+
+    let path = `${namePath}/${type}`;
+    if (this._moduleRegistry.has(path)) {
+      return {name: path, exportName: 'default'};
+    }
+
+    if (isDefaultType) {
+      return { name: namePath, exportName: 'default' };
+    }
+
+    return { name: namePath, exportName: type };
+  },
+
+  // this returns the actual module
+  resolve(lookupString) {
+    let moduleDef = this._resolveLookupStringToModuleName(lookupString);
+    if (moduleDef && this._moduleRegistry.has(moduleDef.name, moduleDef.exportName)) {
+      return this._moduleRegistry.getExport(moduleDef.name, moduleDef.exportName);
+    }
+  },
+
+  _parseLookupString(lookupString) {
+    let [type, name] = lookupString.split(':');
+    let configForType = this.config.types[type];
+    if (!configForType) {
+      throw new Error(`"${type}" not a recognized type`);
+    }
+
+    let { definitiveCollection: collection, fallbackCollectionPrefixes } = configForType;
+
+    // Handle a collection prefix like 'template:components/my-component'
+    if (fallbackCollectionPrefixes) {
+      let collectionPrefix = Object.keys(fallbackCollectionPrefixes).find(prefix => {
+        return name.indexOf(prefix) === 0;
+      });
+
+      if (collectionPrefix) {
+        name = name.slice(collectionPrefix.length);
+        collection = fallbackCollectionPrefixes[collectionPrefix];
+      }
+    }
+
+    let collectionConfig = this.config.collections[collection];
+
+    /* TODO validation incorrect */
+    if (collectionConfig.types.indexOf(type) === -1) {
+      throw new Error(`"${type}" not a recognized type for ${collection} collection`);
+    }
+
+    let isDefaultType = collectionConfig.defaultType === type;
+    let { group } = collectionConfig;
+
+    return { type, collection, group, isDefaultType, name };
+  }
+});
+
+export default Resolver;

--- a/addon/dynamic-resolver.js
+++ b/addon/dynamic-resolver.js
@@ -151,7 +151,7 @@ const Resolver = DefaultResolver.extend({
 
     // Handle a collection prefix like 'template:components/my-component'
     if (fallbackCollectionPrefixes) {
-      let collectionPrefix = Object.keys(fallbackCollectionPrefixes).find(prefix => {
+      let collectionPrefix = Ember.A(Object.keys(fallbackCollectionPrefixes)).find(prefix => {
         return name.indexOf(prefix) === 0;
       });
 

--- a/addon/ember-config.js
+++ b/addon/ember-config.js
@@ -44,6 +44,7 @@ export default {
     },
     components: {
       group: 'ui',
+      defaultType: 'component',
       types: ['component', 'helper', 'template']
     },
     initializers: {

--- a/addon/unified-resolver.js
+++ b/addon/unified-resolver.js
@@ -1,184 +1,18 @@
-import Ember from 'ember';
-import ModuleRegistry from './utils/module-registry';
-import makeDictionary from './utils/make-dictionary';
-
-const { DefaultResolver } = Ember;
+import DynamicResolver from './dynamic-resolver';
 import FallbackResolver from './resolver';
 
-const Resolver = DefaultResolver.extend({
+export default DynamicResolver.extend({
   init() {
     this._super(...arguments);
     this._fallbackResolver = new FallbackResolver(...arguments);
-
-    this._modulePrefix = `${this.namespace.modulePrefix}/src`;
-    if (!this._moduleRegistry) {
-      this._moduleRegistry = new ModuleRegistry();
-    }
-
-    this._normalizeCache = makeDictionary();
   },
 
-  normalize: function(fullName) {
-    return this._normalizeCache[fullName] || (this._normalizeCache[fullName] = this._normalize(fullName));
-  },
-
-  _normalize: function(fullName) {
-    // replace `.` with `/` in order to make nested controllers work in the following cases
-    // 1. `needs: ['posts/post']`
-    // 2. `{{render "posts/post"}}`
-    // 3. `this.render('posts/post')` from Route
-    var split = fullName.split(':');
-    if (split.length > 1) {
-      return split[0] + ':' + Ember.String.dasherize(split[1].replace(/\./g, '/'));
-    } else {
-      return fullName;
-    }
-  },
-
-  expandLocalLookup(lookupString, sourceLookupString) {
-    let { type, name } = this._parseLookupString(lookupString);
-    let source = this._parseLookupString(sourceLookupString);
-    let sourceCollectionConfig = this.config.collections[source.collection];
-
-    // Perhaps should blow up if you are not in the types, TODO bad error state in here
-    let expandedLookupString;
-    if (sourceCollectionConfig.types.indexOf(type) === -1 && sourceCollectionConfig.privateCollections) {
-      let privateCollection;
-      sourceCollectionConfig.privateCollections.forEach(key => {
-        let privateCollectionConfig = this.config.collections[key];
-        // If the lookup type is permitted in this specific private collection
-        if (privateCollectionConfig.types.indexOf(type) !== -1) {
-          if (privateCollection) {
-            throw new Error(`More than one private collection supporting type "${type}" was available in collection ${source.collection}`);
-          }
-          privateCollection = key;
-        }
-      });
-      expandedLookupString = `${type}:${source.name}/-${privateCollection}/${name}`;
-    } else {
-      expandedLookupString = `${type}:${source.name}/${name}`;
-    }
-
-    let { name: moduleName, exportName } = this._resolveLookupStringToModuleName(expandedLookupString);
-
-    if (this._moduleRegistry.has(moduleName) && this._moduleRegistry.getExport(moduleName, exportName)) {
-      return expandedLookupString;
-    }
-
-    return null;
-  },
-
-  _resolveLookupStringToModuleName(lookupString) {
-    let { type, collection, group, isDefaultType, name } = this._parseLookupString(lookupString);
-
-    // Main factories have no collection
-    if (name === 'main') {
-      // throw if the collection is not ''
-      let path = `${this._modulePrefix}/${type}`;
-      if (this._moduleRegistry.has(path)) {
-        return {name: path, exportName: 'default'};
-      }
-      return null;
-      // throw new Error(`Could not resolve factory '${lookupString}' at path '${path}'`);
-    }
-
-    let parts = name.split('/-');
-
-    // If we have a private collection
-    if (parts.length === 2) {
-      let privateCollection = parts[1].split('/')[0];
-
-      if (collection === privateCollection) {
-        // The proposed source collection cannot be correct, since the
-        // private collection is the same. A private collection cannot be
-        // in itself. For example: src/ui/component/phone-book/-components/
-        let alternativeCollections = [];
-        Object.keys(this.config.collections).filter(collection => {
-          let collectionDef = this.config.collections[collection];
-          if (collectionDef.privateCollections && collectionDef.privateCollections.indexOf(privateCollection) !== -1) {
-            alternativeCollections.push(collection);
-          }
-        });
-        if (alternativeCollections.length > 1) {
-          throw new Error('a private collection should not be configured for more than one collection');
-        }
-        collection = alternativeCollections[0];
-        group = this.config.collections[collection].group;
-      } else {
-        let { unresolvableCollections } = this.config;
-        if (unresolvableCollections && unresolvableCollections[privateCollection]) {
-          // Configuring a collection to be { resolvable: false } stops that
-          // collection from being resolved at the top level. It also means that
-          // the collection cannot be used as a private collection regardless of
-          // whether it is listed explicitly as a private collection.
-          throw new Error(`attempted to resolve a module in the unresolvable collection "${privateCollection}"`);
-        }
-      }
-    } else if (parts.length > 2) {
-      throw new Error('Non-ambiguous, but painful to parse case');
-    }
-
-    // Other factories have a collection
-    let groupSegment = group ? `${group}/` : '';
-    let namePath = `${this._modulePrefix}/${groupSegment}${collection}/${name}`;
-
-    let path = `${namePath}/${type}`;
-    if (this._moduleRegistry.has(path)) {
-      return {name: path, exportName: 'default'};
-    }
-
-    if (isDefaultType) {
-      return { name: namePath, exportName: 'default' };
-    }
-
-    return { name: namePath, exportName: type };
-  },
-
-  // this returns the actual module
-  resolve(lookupString) {
-    let resolved = this._fallbackResolver.resolve(lookupString);
+  resolve() {
+    let resolved = this._fallbackResolver.resolve(...arguments);
     if (resolved) {
       return resolved;
     }
-    let moduleDef = this._resolveLookupStringToModuleName(lookupString);
-    if (moduleDef && this._moduleRegistry.has(moduleDef.name, moduleDef.exportName)) {
-      return this._moduleRegistry.getExport(moduleDef.name, moduleDef.exportName);
-    }
-  },
 
-  _parseLookupString(lookupString) {
-    let [type, name] = lookupString.split(':');
-    let configForType = this.config.types[type];
-    if (!configForType) {
-      throw new Error(`"${type}" not a recognized type`);
-    }
-
-    let { definitiveCollection: collection, fallbackCollectionPrefixes } = configForType;
-
-    // Handle a collection prefix like 'template:components/my-component'
-    if (fallbackCollectionPrefixes) {
-      let collectionPrefix = Object.keys(fallbackCollectionPrefixes).find(prefix => {
-        return name.indexOf(prefix) === 0;
-      });
-
-      if (collectionPrefix) {
-        name = name.slice(collectionPrefix.length);
-        collection = fallbackCollectionPrefixes[collectionPrefix];
-      }
-    }
-
-    let collectionConfig = this.config.collections[collection];
-
-    /* TODO validation incorrect */
-    if (collectionConfig.types.indexOf(type) === -1) {
-      throw new Error(`"${type}" not a recognized type for ${collection} collection`);
-    }
-
-    let isDefaultType = collectionConfig.defaultType === type;
-    let { group } = collectionConfig;
-
-    return { type, collection, group, isDefaultType, name };
+    return this._super(...arguments);
   }
 });
-
-export default Resolver;

--- a/addon/unified-resolver.js
+++ b/addon/unified-resolver.js
@@ -3,10 +3,12 @@ import ModuleRegistry from './utils/module-registry';
 import makeDictionary from './utils/make-dictionary';
 
 const { DefaultResolver } = Ember;
+import FallbackResolver from './resolver';
 
 const Resolver = DefaultResolver.extend({
   init() {
     this._super(...arguments);
+    this._fallbackResolver = new FallbackResolver(...arguments);
 
     this._modulePrefix = `${this.namespace.modulePrefix}/src`;
     if (!this._moduleRegistry) {
@@ -134,8 +136,12 @@ const Resolver = DefaultResolver.extend({
 
   // this returns the actual module
   resolve(lookupString) {
+    let resolved = this._fallbackResolver.resolve(lookupString);
+    if (resolved) {
+      return resolved;
+    }
     let moduleDef = this._resolveLookupStringToModuleName(lookupString);
-    if (moduleDef && this._moduleRegistry.has(moduleDef.name)) {
+    if (moduleDef && this._moduleRegistry.has(moduleDef.name, moduleDef.exportName)) {
       return this._moduleRegistry.getExport(moduleDef.name, moduleDef.exportName);
     }
   },

--- a/tests/unit/unified-resolver/basic-dynamic-test.js
+++ b/tests/unit/unified-resolver/basic-dynamic-test.js
@@ -1,10 +1,10 @@
 /* jshint loopfunc:true */
 import { module, test } from 'qunit';
-import Resolver from 'dangerously-set-unified-resolver/unified-resolver';
+import Resolver from 'dangerously-set-unified-resolver/dynamic-resolver';
 
 let modulePrefix = 'test-namespace';
 
-module('ember-resolver/unified-resolver', {});
+module('ember-resolver/dynamic-resolver', {});
 
 class NewFakeRegistry {
   constructor({moduleOverrides}) {
@@ -34,7 +34,7 @@ function expectResolutions({ message, config, resolutions, moduleOverrides, erro
   let fakeRegistry = new NewFakeRegistry({
     moduleOverrides
   });
-  let resolver = Resolver.create({
+  let resolver = new Resolver({
     config,
     _moduleRegistry: fakeRegistry,
     namespace: {modulePrefix}

--- a/tests/unit/unified-resolver/expand-local-lookup-test.js
+++ b/tests/unit/unified-resolver/expand-local-lookup-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import Resolver from 'dangerously-set-unified-resolver/unified-resolver';
+import Resolver from 'dangerously-set-unified-resolver/dynamic-resolver';
 
 let modulePrefix = 'test-prefix';
 
-module('ember-resolver/unified-resolver #expandLocalLookup', {
+module('ember-resolver/dynamic-resolver #expandLocalLookup', {
 });
 
 class FakeRegistry {

--- a/tests/unit/unified-resolver/fallback-test.js
+++ b/tests/unit/unified-resolver/fallback-test.js
@@ -1,0 +1,96 @@
+/* jshint loopfunc:true */
+import { module, test } from 'qunit';
+import Resolver from 'dangerously-set-unified-resolver/unified-resolver';
+import DefaultConfig from 'dangerously-set-unified-resolver/ember-config';
+import Ember from 'ember';
+
+let modulePrefix = 'test-namespace';
+const underscore = Ember.String.underscore;
+
+module('ember-resolver/unified-resolver - fallback tests', {});
+
+class RecordingRegistry {
+  constructor() {
+    this._lookups = [];
+  }
+
+  get _uniqueLookups() {
+    return Ember.A(this._lookups).uniq();
+  }
+
+  get(moduleName) {
+    this._lookups.push(lookupName);
+    
+    throw new Error('RecordingRegistry raises on all `get` calls');
+  }
+
+  getExport(moduleName, exportName = 'default') {
+    let lookupName = moduleName;
+    if (exportName !== 'default') {
+      lookupName = lookupName + ':' + exportName;
+    }
+    this._lookups.push(lookupName);
+
+    throw new Error('RecordingRegistry raises on all `getExport` calls');
+  }
+
+  has(moduleName, exportName='default') {
+    let lookupName = moduleName;
+    if (exportName !== 'default') {
+      lookupName = lookupName + ':' + exportName;
+    }
+    this._lookups.push(lookupName);
+    return false;
+  }
+}
+
+function expectResolutions(lookupName, orderedSearchPaths) {
+  test(`resolve ${lookupName}`, function(assert) {
+    assert.expect(2);
+
+    let registry = new RecordingRegistry();
+
+    let resolver = new Resolver({
+      config: DefaultConfig,
+      namespace: {modulePrefix},
+      _moduleRegistry: registry
+    });
+
+    let resolved = resolver.resolve(lookupName);
+
+    assert.ok(resolved === undefined, 'precond - resolves to undefined');
+    assert.deepEqual(registry._uniqueLookups, orderedSearchPaths);
+  });
+}
+
+expectResolutions('component:foo-bar', [
+  // "old" resolver:
+             `${modulePrefix}/foo-bar/component`,
+  underscore(`${modulePrefix}/foo-bar/component`),
+
+             `${modulePrefix}/components/foo-bar/component`,
+  underscore(`${modulePrefix}/components/foo-bar/component`),
+
+             `${modulePrefix}/components/foo-bar`,
+  underscore(`${modulePrefix}/components/foo-bar`),
+
+  // "unified" resolver:
+  `${modulePrefix}/src/ui/components/foo-bar/component`,
+  `${modulePrefix}/src/ui/components/foo-bar`,
+]);
+
+expectResolutions('template:components/foo-bar', [
+  // "old" resolver:
+             `${modulePrefix}/foo-bar/template`,
+  underscore(`${modulePrefix}/foo-bar/template`),
+
+             `${modulePrefix}/components/foo-bar/template`,
+  underscore(`${modulePrefix}/components/foo-bar/template`),
+
+             `${modulePrefix}/templates/components/foo-bar`,
+  underscore(`${modulePrefix}/templates/components/foo-bar`),
+
+  // "unified" resolver:
+  `${modulePrefix}/src/ui/components/foo-bar/template`,
+  `${modulePrefix}/src/ui/components/foo-bar:template`,
+]);

--- a/tests/unit/unified-resolver/fallback-test.js
+++ b/tests/unit/unified-resolver/fallback-test.js
@@ -9,6 +9,8 @@ const underscore = Ember.String.underscore;
 
 module('ember-resolver/unified-resolver - fallback tests', {});
 
+// The recording registry keeps track of all the moduleName/exports that
+// it attempts to look up (through `has`, `get` or `getExport`)
 class RecordingRegistry {
   constructor() {
     this._lookups = [];
@@ -18,12 +20,17 @@ class RecordingRegistry {
     return Ember.A(this._lookups).uniq();
   }
 
+  /*
+   * not needed (yet?)
   get(moduleName) {
-    this._lookups.push(lookupName);
+    this._lookups.push(moduleName);
     
     throw new Error('RecordingRegistry raises on all `get` calls');
   }
+  */
 
+  /*
+   * not needed (yet?)
   getExport(moduleName, exportName = 'default') {
     let lookupName = moduleName;
     if (exportName !== 'default') {
@@ -33,6 +40,7 @@ class RecordingRegistry {
 
     throw new Error('RecordingRegistry raises on all `getExport` calls');
   }
+  */
 
   has(moduleName, exportName='default') {
     let lookupName = moduleName;


### PR DESCRIPTION
_do not merge_

This is a start towards implementing "fallback" resolver behavior.
This adds some new tests that assert the search paths that are looked up (in order) to find a component and its template. It asserts that the current resolver's search paths are looked at first before looking for module names that the module unification RFC specifies to use.
- Moves "unified-resolver" to "dynamic-resolver"
- Creates new "unified-resolver" that extends dynamic-resolver and creates an instance of a "fallback" resolver (aka the current non-module-unified resolver); it consults first the fallback, then its super method, when it `resolve`s
- make tests pass except for in Ember 1.13

Tests fail for ember 1.13 because calling `new Resolver` doesn't result in the `arguments` being present in the `init` method, and as a result when the unified resolver attempts to create its "fallback" resolver (aka the current, non-module-unified) resolver, it doesn't pass the same arguments to it.

cc @iezer 
