### PR TITLE
Remove expand local lookup try catch

### DIFF
--- a/addon/fallback-resolver.js
+++ b/addon/fallback-resolver.js
@@ -10,7 +10,7 @@ export default UnifiedResolver.extend({
     this._fallbackResolver.namespace = this.namespace;
   },
 
-  _resolve() {
+  resolve() {
     return this._fallbackResolver.resolve(...arguments) || this._super(...arguments);
   }
 });

--- a/addon/unified-resolver.js
+++ b/addon/unified-resolver.js
@@ -40,32 +40,29 @@ const Resolver = DefaultResolver.extend({
   // Need to think of a more general solution that can be configurable.
   // See the tests for examples of what gets passed from Ember.
   expandLocalLookup(fullName, source) {
+    if (!source) { return; }
     let namespaceRegex = /template:(.*)\/templates\/src\/ui\/(.*)\/template\/hbs/;
     let match = source.match(namespaceRegex);
+
+    if (!match || match.length < 3) { return; }
     let appName = match[1];
     let namespace = match[2];
 
     match = fullName.match(/(.*):(components\/)?(.*)/);
+    if (!match || match.length < 4) { return; }
     let type = match[1];
     let name = match[3];
 
     let expandedPath = `${type}:/${appName}/${namespace}/${name}`;
+    let exists = this.glimmerRegistry.has(this._glimmerResolver.identify(expandedPath));
+    console.log(`expandLocalLookup: ${fullName} ${source} -> ${expandedPath} ${exists}`);
 
-    // TODO non-performant. Need a non-error-throwing way of checking
-    // if the expandedPath actually exists.
-    try {
-      this.resolve(expandedPath);
-    } catch(e) {
-      console.log(`expandedLocalLookup ERROR ${fullName} ${source} --> ${expandedPath}`);
-      return;
-    }
-
-    console.log(`expandLocalLookup ${fullName} ${source} --> ${expandedPath}`);
-    return expandedPath;
+    return exists && expandedPath;
   },
 
   resolve(lookupString, source) {
     let normalized = this.normalize(lookupString);
+    console.log(`resolving ${lookupString} source: ${source}`);
     return this._glimmerResolver.resolve(normalized, source);
   }
 });

--- a/tests/unit/requirejs-registry-test.js
+++ b/tests/unit/requirejs-registry-test.js
@@ -1,47 +1,48 @@
 import RequireJSRegistry from 'dangerously-set-unified-resolver/utils/requirejs-registry';
 import { module, test} from 'qunit';
 
-module('RequireJS Registry', {
-  beforeEach() {
-   let config = {
-    app: {
-      name: 'example-app',
-      rootName: 'example-app'
-    },
-    types: {
-      component: { definitiveCollection: 'components' },
-      partial: { definiteCollection: 'partials' },
-      route: { definitiveCollection: 'routes' },
-      router: { definitiveCollection: 'main' },
-      template: {
-        definitiveCollection: 'routes',
-        fallbackCollectionPrefixes: {
-          'components': 'components'
-        }
-      }
-    },
-    collections: {
-      'main': {
-        types: ['router']
-      },
-      components: {
-        group: 'ui',
-        types: ['component', 'helper', 'template']
-      },
-      partials: {
-        group: 'ui',
-        types: [ 'template' ]
-      },
-      routes: {
-        group: 'ui',
-        privateCollections: ['components'],
-        types: ['route', 'controller', 'template']
+export let config = {
+  app: {
+    name: 'example-app',
+    rootName: 'example-app'
+  },
+  types: {
+    component: { definitiveCollection: 'components' },
+    partial: { definiteCollection: 'partials' },
+    route: { definitiveCollection: 'routes' },
+    router: { definitiveCollection: 'main' },
+    template: {
+      definitiveCollection: 'routes',
+      fallbackCollectionPrefixes: {
+        'components': 'components'
       }
     }
-  };
+  },
+  collections: {
+    'main': {
+      types: ['router']
+    },
+    components: {
+      group: 'ui',
+      types: ['component', 'helper', 'template']
+    },
+    partials: {
+      group: 'ui',
+      types: [ 'template' ]
+    },
+    routes: {
+      group: 'ui',
+      privateCollections: ['components'],
+      types: ['route', 'controller', 'template']
+    }
+  }
+};
 
-  this.config = config;
-  this.registry = new RequireJSRegistry(this.config, 'src');
+module('RequireJS Registry', {
+  beforeEach() {
+
+    this.config = config;
+    this.registry = new RequireJSRegistry(this.config, 'src');
   }
 });
 

--- a/tests/unit/unified-resolver/expand-local-lookup-test.js
+++ b/tests/unit/unified-resolver/expand-local-lookup-test.js
@@ -1,41 +1,69 @@
 import { module, test } from 'qunit';
 import Resolver from 'dangerously-set-unified-resolver/unified-resolver';
+import { config } from '../requirejs-registry-test';
 
 module('ember-resolver/unified-resolver #expandLocalLookup', {
   beforeEach() {
     this.resolver = Resolver.create({
-      resolve() {
-        // No op
+      config,
+      glimmerRegistry: {
+        entries: [],
+        has(path) {
+          return path in this.entries;
+        }
       }
     });
+
+    this.registerPath = (path) => {
+      this.resolver.glimmerRegistry.entries[path] = true;
+    };
   }
 });
 
-test('expandLookupLocalLookup', function(assert) {
+test('expandLocalLookup returns absolute specifier when the registry has it.', function(assert) {
   assert.expect(4);
 
   [
     [
-      'component:my-button', 
+      'component:my-button',
       'template:my-app/templates/src/ui/routes/index/template/hbs',
       'component:/my-app/routes/index/my-button'
     ],
-    [ 
+    [
       'template:components/my-button',
       'template:my-app/templates/src/ui/routes/index/template/hbs',
       'template:/my-app/routes/index/my-button'
     ],
     [
-      'component:my-button', 
-      'template:my-app/templates/src/ui/components/my-input/template/hbs', 
+      'component:my-button',
+      'template:my-app/templates/src/ui/components/my-input/template/hbs',
       'component:/my-app/components/my-input/my-button'
     ],
     [
-      'template:components/my-button', 
+      'template:components/my-button',
       'template:my-app/templates/src/ui/components/my-input/template/hbs',
       'template:/my-app/components/my-input/my-button'
     ]
   ].forEach(([ fullName, source, expected ]) => {
+    this.registerPath(expected);
     assert.equal(this.resolver.expandLocalLookup(fullName, source), expected, `expected ${expected} for ${fullName} from ${source}.`);
   });
+});
+
+test('expandLocalLookup returns null when registry.has returns null', function(assert) {
+  let fullName = 'component:foo-bar';
+  let source = 'template:my-app/templates/src/ui/routes/index/template/hbs';
+  assert.notOk(this.resolver.expandLocalLookup(fullName, source));
+});
+
+test('expandLocalLookup returns null when it cannot parse the source', function(assert) {
+  let fullName = 'component:foo-bar';
+  assert.notOk(this.resolver.expandLocalLookup(fullName));
+  assert.notOk(this.resolver.expandLocalLookup(fullName, 'blah'));
+  assert.notOk(this.resolver.expandLocalLookup(fullName, 'template/blah'));
+});
+
+test('expandLocalLookup returns null when it cannot parse the fullName', function(assert) {
+  let source = 'template:my-app/templates/src/ui/routes/index/template/hbs';
+  assert.notOk(this.resolver.expandLocalLookup('foo-bar', source));
 });


### PR DESCRIPTION
@mixonic This PR refactors `expandLocalLookup` so that if can detect if the module exists by calling `glimmerRegistry.has` instead of using a `try/catch`. 

Also fixes the `fallback-resolver` (the one that runs both the old and new).

I added a few tests for `expandLocalLookup` to make my assumptions clear.

The latest version of [`--new-app-blueprint/glimmer-resolver`](https://github.com/rwjblue/--new-app-blueprint/compare/master...201-created:glimmer-resolver?expand=1) has commits to add two partials:
 * `src/ui/partials/author.hbs` (new)
 * `app/templates/-post.hbs` (legacy)

The new app also has an Ember Data model, serializer, and adapter and they all work.

I paired on some of this with @dgeb