### PR TITLE
move glimmer dependencies non-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,6 @@
   "author": "Robert Jackson <me@rwjblue.com>",
   "license": "MIT",
   "devDependencies": {
-    "@glimmer/build": "^0.2.1",
-    "@glimmer/di": "^0.1.8",
-    "@glimmer/resolver": "^0.2.0",
-    "@glimmer/util": "^0.21.0",
     "broccoli-asset-rev": "^2.4.2",
     "broccoli-babel-transpiler": "^5.6.2",
     "broccoli-funnel": "^1.0.7",
@@ -49,6 +45,10 @@
     "ember-addon"
   ],
   "dependencies": {
+    "@glimmer/build": "^0.2.1",
+    "@glimmer/di": "^0.1.8",
+    "@glimmer/resolver": "^0.2.0",
+    "@glimmer/util": "^0.21.0",
     "ember-cli-babel": "^5.1.7",
     "ember-cli-version-checker": "^1.1.6",
     "broccoli-funnel": "^1.0.7",


### PR DESCRIPTION
Allows new-app-blueprint to work without having to specifier these glimmer dependencies.

Follow up task: remove from new-app-blueprint's package.json