### PR TITLE
Isaac/travis updates

### DIFF
--- a/addon/ember-config.js
+++ b/addon/ember-config.js
@@ -60,6 +60,9 @@ export default {
       group: 'data',
       types: ['model', 'adapter', 'serializer']
     },
+    locations: {
+      types: ['location']
+    },
     partials: {
       group: 'ui',
       types: ['partial']

--- a/addon/unified-resolver.js
+++ b/addon/unified-resolver.js
@@ -53,7 +53,7 @@ const Resolver = DefaultResolver.extend({
     let type = match[1];
     let name = match[3];
 
-    let expandedPath = `${type}:/${appName}/${namespace}/${name}`;
+    let expandedPath = `${type}:/${appName}/${namespace}/-components/${name}`;
     let exists = this.glimmerRegistry.has(this._glimmerResolver.identify(expandedPath));
     console.log(`expandLocalLookup: ${fullName} ${source} -> ${expandedPath} ${exists}`);
 

--- a/addon/utils/requirejs-registry.js
+++ b/addon/utils/requirejs-registry.js
@@ -5,12 +5,14 @@ import {
 
 export default class RequireJSRegistry {
 
-  constructor(config, modulePrefix) {
+  constructor(config, modulePrefix, _requirejs = requirejs, _require = require) {
     this._config = config;
     this._modulePrefix = modulePrefix;
+    this.requirejs = _requirejs;
+    this.require = _require;
   }
 
-  normalize(specifier) {
+  _normalize(specifier) {
     let s = deserializeSpecifier(specifier);
 
     // This is hacky solution to get around the fact that Ember
@@ -53,23 +55,46 @@ export default class RequireJSRegistry {
       segments.push(s.name);
     }
 
-    if (!isPartial) {
+    // Things like a service or route can exist at
+    // my-app/src/ui/routes/application or
+    // my-app/src/ui/routes/application/route
+    // Certain things like templates, things are exist as 'main',
+    // and partials, cannot.
+    // TODO MAKE CONFIGURABLE
+    const allowOptionalTypeSuffix = (s.collection !== 'main') &&
+          (s.type !== 'template') &&
+          (!isPartial);
+
+    const type = allowOptionalTypeSuffix ? s.type : '';
+
+    if (!allowOptionalTypeSuffix && !isPartial) {
       segments.push(s.type);
     }
 
     let path = segments.join('/');
+    console.log(`requirejs ${specifier} -> ${path}, ${type}`);
 
-    console.log(`requirejs ${specifier} -> ${path}`);
-    return path;
+    return {
+      path,
+      type
+    };
   }
 
   has(specifier) {
-    let path = this.normalize(specifier);
-    return path in requirejs.entries;
+    const { path, type } = this._normalize(specifier);
+
+    if (path in this.requirejs.entries) {
+      return true;
+    }
+
+    if (type) {
+      return `${path}/${type}` in this.requirejs.entries;
+    }
   }
 
   get(specifier) {
-    let path = this.normalize(specifier);
-    return require(path).default;
+    const { path, type } = this._normalize(specifier);
+    let result = this.require(path) || (type && this.require(`${path}/${type}`));
+    return result.default;
   }
 }

--- a/addon/utils/requirejs-registry.js
+++ b/addon/utils/requirejs-registry.js
@@ -45,6 +45,8 @@ export default class RequireJSRegistry {
 
     if (s.namespace) {
       segments.push(s.namespace);
+    } else if (s.type === 'location') {
+      segments.push('locations');
     }
 
     if (s.name !== 'main') {

--- a/index.js
+++ b/index.js
@@ -8,9 +8,6 @@ var path = require('path');
 
 var renameMap = {
   'src/main.js': 'app.js',
-  'src/resolver.js': 'resolver.js',
-  'src/ui/styles/app.css': 'styles/app.css',
-  'src/ui/index.html': 'index.html'
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "broccoli-babel-transpiler": "^5.6.2",
     "broccoli-funnel": "^1.0.7",
     "broccoli-merge-trees": "^1.1.4",
-    "ember-cli": "2.10.0",
+    "ember-cli": "ember-cli/ember-cli#master",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,6 @@
   "author": "Robert Jackson <me@rwjblue.com>",
   "license": "MIT",
   "devDependencies": {
-    "@glimmer/build": "^0.2.1",
-    "@glimmer/di": "^0.1.8",
-    "@glimmer/resolver": "^0.2.0",
-    "@glimmer/util": "^0.21.0",
     "broccoli-asset-rev": "^2.4.2",
     "broccoli-babel-transpiler": "^5.6.2",
     "broccoli-funnel": "^1.0.7",
@@ -49,6 +45,10 @@
     "ember-addon"
   ],
   "dependencies": {
+    "@glimmer/build": "^0.2.1",
+    "@glimmer/di": "^0.1.8",
+    "@glimmer/resolver": "^0.2.0",
+    "@glimmer/util": "^0.21.0",
     "ember-cli-babel": "^5.1.7",
     "ember-cli-version-checker": "^1.1.6",
     "broccoli-funnel": "^1.0.7",

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -1,0 +1,3 @@
+<html>
+  <!-- Empty commit required to get to build with ember-cli#master TODO REMOVE -->
+</html>

--- a/tests/unit/requirejs-registry-test.js
+++ b/tests/unit/requirejs-registry-test.js
@@ -8,7 +8,9 @@ export let config = {
   },
   types: {
     component: { definitiveCollection: 'components' },
+    location: { definitiveCollection: 'locations' },
     partial: { definiteCollection: 'partials' },
+    service: { definitiveCollection: 'services' },
     route: { definitiveCollection: 'routes' },
     router: { definitiveCollection: 'main' },
     template: {
@@ -26,6 +28,9 @@ export let config = {
       group: 'ui',
       types: ['component', 'helper', 'template']
     },
+    locations: {
+      types: ['location']
+    },
     partials: {
       group: 'ui',
       types: [ 'template' ]
@@ -34,6 +39,9 @@ export let config = {
       group: 'ui',
       privateCollections: ['components'],
       types: ['route', 'controller', 'template']
+    },
+    services: {
+      types: ['service']
     }
   }
 };
@@ -47,7 +55,7 @@ module('RequireJS Registry', {
 });
 
 test('Normalize', function(assert) {
-  assert.expect(9);
+  assert.expect(11);
 
   [
     [ 'router:/my-app/main/main', 'my-app/src/router' ],
@@ -58,9 +66,11 @@ test('Normalize', function(assert) {
     [ 'template:/my-app/components/my-input', 'my-app/src/ui/components/my-input/template' ],
     [ 'component:/my-app/components/my-input/my-button', 'my-app/src/ui/components/my-input/my-button/component' ],
     [ 'template:/my-app/components/my-input/my-button', 'my-app/src/ui/components/my-input/my-button/template' ],
-    [ 'template:/my-app/routes/-author', 'my-app/src/ui/partials/author' ]
+    [ 'template:/my-app/routes/-author', 'my-app/src/ui/partials/author' ],
+    [ 'service:/my-app/services/auth', 'my-app/src/services/auth/service' ],
+    [ 'location:/my-app/main/auth-dependent', 'my-app/src/locations/auth-dependent/location' ]
   ]
   .forEach(([ lookupString, expected ]) => {
-    assert.equal(this.registry.normalize(lookupString), expected);
+    assert.equal(this.registry.normalize(lookupString), expected, `normalize ${lookupString} -> ${expected}`);
   });
 });

--- a/tests/unit/requirejs-registry-test.js
+++ b/tests/unit/requirejs-registry-test.js
@@ -48,29 +48,56 @@ export let config = {
 
 module('RequireJS Registry', {
   beforeEach() {
-
     this.config = config;
-    this.registry = new RequireJSRegistry(this.config, 'src');
   }
 });
 
 test('Normalize', function(assert) {
   assert.expect(11);
+  this.registry = new RequireJSRegistry(this.config, 'src');
+
+  [
+    [ 'router:/my-app/main/main', 'my-app/src/router', '' ],
+    [ 'route:/my-app/routes/application', 'my-app/src/ui/routes/application', 'route' ],
+    [ 'template:/my-app/routes/application', 'my-app/src/ui/routes/application/template', '' ],
+    [ 'component:/my-app/components/my-input', 'my-app/src/ui/components/my-input', 'component' ],
+    [ 'template:/my-app/routes/components/my-input', 'my-app/src/ui/components/my-input/template', '' ],
+    [ 'template:/my-app/components/my-input', 'my-app/src/ui/components/my-input/template', '' ],
+    [ 'component:/my-app/components/my-input/my-button', 'my-app/src/ui/components/my-input/my-button', 'component' ],
+    [ 'template:/my-app/components/my-input/my-button', 'my-app/src/ui/components/my-input/my-button/template', '' ],
+    [ 'template:/my-app/routes/-author', 'my-app/src/ui/partials/author', '' ],
+    [ 'service:/my-app/services/auth', 'my-app/src/services/auth', 'service' ],
+    [ 'location:/my-app/main/auth-dependent', 'my-app/src/locations/auth-dependent/location', '' ]
+  ]
+  .forEach(([ lookupString, path, type ]) => {
+    assert.deepEqual(this.registry._normalize(lookupString), { path, type }, `normalize ${lookupString} -> ${path}, ${type}`);
+  });
+});
+
+test('has', function(assert) {
+  assert.expect(15);
 
   [
     [ 'router:/my-app/main/main', 'my-app/src/router' ],
+    [ 'route:/my-app/routes/application', 'my-app/src/ui/routes/application' ],
     [ 'route:/my-app/routes/application', 'my-app/src/ui/routes/application/route' ],
     [ 'template:/my-app/routes/application', 'my-app/src/ui/routes/application/template' ],
+    [ 'component:/my-app/components/my-input', 'my-app/src/ui/components/my-input' ],
     [ 'component:/my-app/components/my-input', 'my-app/src/ui/components/my-input/component' ],
     [ 'template:/my-app/routes/components/my-input', 'my-app/src/ui/components/my-input/template' ],
     [ 'template:/my-app/components/my-input', 'my-app/src/ui/components/my-input/template' ],
+    [ 'component:/my-app/components/my-input/my-button', 'my-app/src/ui/components/my-input/my-button' ],
     [ 'component:/my-app/components/my-input/my-button', 'my-app/src/ui/components/my-input/my-button/component' ],
     [ 'template:/my-app/components/my-input/my-button', 'my-app/src/ui/components/my-input/my-button/template' ],
     [ 'template:/my-app/routes/-author', 'my-app/src/ui/partials/author' ],
+    [ 'service:/my-app/services/auth', 'my-app/src/services/auth' ],
     [ 'service:/my-app/services/auth', 'my-app/src/services/auth/service' ],
     [ 'location:/my-app/main/auth-dependent', 'my-app/src/locations/auth-dependent/location' ]
   ]
-  .forEach(([ lookupString, expected ]) => {
-    assert.equal(this.registry.normalize(lookupString), expected, `normalize ${lookupString} -> ${expected}`);
+  .forEach(([ lookupString, expectedPath ]) => {
+    const mockEntries = [];
+    mockEntries[expectedPath] = true;
+    this.registry = new RequireJSRegistry(this.config, 'src', { entries: mockEntries });
+    assert.ok(this.registry.has(lookupString), `registry has ${lookupString} at ${expectedPath}`);
   });
 });

--- a/tests/unit/unified-resolver/expand-local-lookup-test.js
+++ b/tests/unit/unified-resolver/expand-local-lookup-test.js
@@ -27,22 +27,22 @@ test('expandLocalLookup returns absolute specifier when the registry has it.', f
     [
       'component:my-button',
       'template:my-app/templates/src/ui/routes/index/template/hbs',
-      'component:/my-app/routes/index/my-button'
+      'component:/my-app/routes/index/-components/my-button'
     ],
     [
       'template:components/my-button',
       'template:my-app/templates/src/ui/routes/index/template/hbs',
-      'template:/my-app/routes/index/my-button'
+      'template:/my-app/routes/index/-components/my-button'
     ],
     [
       'component:my-button',
       'template:my-app/templates/src/ui/components/my-input/template/hbs',
-      'component:/my-app/components/my-input/my-button'
+      'component:/my-app/components/my-input/-components/my-button'
     ],
     [
       'template:components/my-button',
       'template:my-app/templates/src/ui/components/my-input/template/hbs',
-      'template:/my-app/components/my-input/my-button'
+      'template:/my-app/components/my-input/-components/my-button'
     ]
   ].forEach(([ fullName, source, expected ]) => {
     this.registerPath(expected);


### PR DESCRIPTION
A few tasks that came up when making https://github.com/201-created/travis-web work:

 - Local lookup works in in hte `-components/branch`
 - Services and some other types can exist in multiple places, such `my-app/src/services/auth` and `my-app/src/services/auth/service`.
 - Add `location` type
 - Ability to mock `requirejs` and `require` in tests.
 - Move `glimmer` stuff to non-dev npm dependencies. Required for now but can be refactored later to slim down the build, we only use 1 deserialization helper function.