### PR TITLE
Isaac/glimmer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [v4.1.0](https://github.com/ember-cli/ember-resolver/tree/v4.1.0) (2017-03-28)
+[Full Changelog](https://github.com/ember-cli/ember-resolver/compare/v4.0.0...v4.1.0)
+
+**Merged pull requests:**
+
+- Initial implementation of the module unification feature flag [\#182](https://github.com/ember-cli/ember-resolver/pull/182) ([mixonic](https://github.com/mixonic))
+- Feature flags [\#180](https://github.com/ember-cli/ember-resolver/pull/180) ([mixonic](https://github.com/mixonic))
+
 ## [v4.0.0](https://github.com/ember-cli/ember-resolver/tree/v4.0.0) (2017-03-25)
 [Full Changelog](https://github.com/ember-cli/ember-resolver/compare/v3.0.1...v4.0.0)
 

--- a/mu-trees/addon/resolvers/glimmer-wrapper/index.js
+++ b/mu-trees/addon/resolvers/glimmer-wrapper/index.js
@@ -22,12 +22,12 @@ const Resolver = DefaultResolver.extend({
 
   normalize: null,
 
-  resolve(lookupString) {
-    return this._resolve(lookupString);
+  resolve(lookupString, referrer) {
+    return this._resolve(lookupString, referrer);
   },
 
-  _resolve(lookupString) {
-    return this._glimmerResolver.resolve(lookupString);
+  _resolve(lookupString, referrer) {
+    return this._glimmerResolver.resolve(lookupString, referrer);
   }
 });
 

--- a/mu-trees/tests/unit/module-registries/requirejs-test.js
+++ b/mu-trees/tests/unit/module-registries/requirejs-test.js
@@ -8,6 +8,7 @@ export let config = {
   },
   types: {
     component: { definitiveCollection: 'components' },
+    location: { definitiveCollection: 'locations' },
     partial: { definiteCollection: 'partials' },
     service: { definitiveCollection: 'services' },
     route: { definitiveCollection: 'routes' },
@@ -44,28 +45,57 @@ export let config = {
 
 module('RequireJS Registry', {
   beforeEach() {
-
     this.config = config;
-    this.registry = new RequireJSRegistry(this.config, 'src');
   }
 });
 
 test('Normalize', function(assert) {
-  assert.expect(10);
+  assert.expect(11);
+  this.registry = new RequireJSRegistry(this.config, 'src');
+
+  [
+    [ 'router:/my-app/main/main', 'my-app/src/router', '' ],
+    [ 'route:/my-app/routes/application', 'my-app/src/ui/routes/application', 'route' ],
+    [ 'template:/my-app/routes/application', 'my-app/src/ui/routes/application/template', '' ],
+    [ 'component:/my-app/components/my-input', 'my-app/src/ui/components/my-input', 'component' ],
+    [ 'template:/my-app/routes/components/my-input', 'my-app/src/ui/components/my-input/template', '' ],
+    [ 'template:/my-app/components/my-input', 'my-app/src/ui/components/my-input/template', '' ],
+    [ 'component:/my-app/components/my-input/my-button', 'my-app/src/ui/components/my-input/my-button', 'component' ],
+    [ 'template:/my-app/components/my-input/my-button', 'my-app/src/ui/components/my-input/my-button/template', '' ],
+    [ 'template:/my-app/routes/-author', 'my-app/src/ui/partials/author', '' ],
+    [ 'service:/my-app/services/auth', 'my-app/src/services/auth', 'service' ],
+    [ 'location:/my-app/main/auth-dependent', 'my-app/src/locations/auth-dependent', 'location' ]
+  ]
+  .forEach(([ lookupString, path, type ]) => {
+    assert.deepEqual(this.registry.normalize(lookupString), { path, type }, `normalize ${lookupString} -> ${path}, ${type}`);
+  });
+});
+
+test('has', function(assert) {
+  assert.expect(16);
 
   [
     [ 'router:/my-app/main/main', 'my-app/src/router' ],
+    [ 'route:/my-app/routes/application', 'my-app/src/ui/routes/application' ],
     [ 'route:/my-app/routes/application', 'my-app/src/ui/routes/application/route' ],
     [ 'template:/my-app/routes/application', 'my-app/src/ui/routes/application/template' ],
+    [ 'component:/my-app/components/my-input', 'my-app/src/ui/components/my-input' ],
     [ 'component:/my-app/components/my-input', 'my-app/src/ui/components/my-input/component' ],
     [ 'template:/my-app/routes/components/my-input', 'my-app/src/ui/components/my-input/template' ],
     [ 'template:/my-app/components/my-input', 'my-app/src/ui/components/my-input/template' ],
+    [ 'component:/my-app/components/my-input/my-button', 'my-app/src/ui/components/my-input/my-button' ],
     [ 'component:/my-app/components/my-input/my-button', 'my-app/src/ui/components/my-input/my-button/component' ],
     [ 'template:/my-app/components/my-input/my-button', 'my-app/src/ui/components/my-input/my-button/template' ],
     [ 'template:/my-app/routes/-author', 'my-app/src/ui/partials/author' ],
-    [ 'service:/my-app/services/auth', 'my-app/src/services/auth/service' ]
+    [ 'service:/my-app/services/auth', 'my-app/src/services/auth' ],
+    [ 'service:/my-app/services/auth', 'my-app/src/services/auth/service' ],
+    [ 'location:/my-app/main/auth-dependent', 'my-app/src/locations/auth-dependent' ],
+    [ 'location:/my-app/main/auth-dependent', 'my-app/src/locations/auth-dependent/location' ]
   ]
-  .forEach(([ lookupString, expected ]) => {
-    assert.equal(this.registry.normalize(lookupString), expected, `normalize ${lookupString} -> ${expected}`);
+  .forEach(([ lookupString, expectedPath ]) => {
+    const mockEntries = [];
+    mockEntries[expectedPath] = true;
+    this.registry = new RequireJSRegistry(this.config, 'src', { entries: mockEntries });
+    assert.ok(this.registry.has(lookupString), `registry has ${lookupString} at ${expectedPath}`);
   });
 });

--- a/mu-trees/tests/unit/resolvers/glimmer-wrapper/basic-test.js
+++ b/mu-trees/tests/unit/resolvers/glimmer-wrapper/basic-test.js
@@ -325,3 +325,87 @@ test('Can resolve a top level template of a definitive type', function(assert) {
     'relative module specifier with source resolved'
   );
 });
+
+test('Can resolve a private component & template for a route using local lookup; nested under /-components', function(assert) {
+  let template = {};
+  let component = {};
+  let componentTemplate = {};
+  let resolver = this.resolverForEntries({
+    app: {
+      name: 'example-app'
+    },
+    types: {
+      component: { definitiveCollection: 'components' },
+      route: { definitiveCollection: 'routes' },
+      template: { definitiveCollection: 'components' }
+    },
+    collections: {
+      components: {
+        group: 'ui',
+        types: [ 'component', 'template' ]
+      },
+      routes: {
+        group: 'ui',
+        types: [ 'route', 'template' ]
+      }
+    }
+  }, {
+    'template:/app/routes/posts': template,
+    'template:/app/routes/posts/-components/my-input': componentTemplate,
+    'component:/app/routes/posts/-components/my-input': component
+  });
+
+  assert.equal(
+    resolver.resolve('component:my-input', 'template:/app/routes/posts/-components'),
+    component,
+    'relative component module specifier with source resolved'
+  );
+
+  assert.equal(
+    resolver.resolve('template:my-input', 'template:/app/routes/posts/-components'),
+    componentTemplate,
+    'relative template module specifier with source resolved'
+  );
+});
+
+test('Can resolve a private component & template belonging to another component using local lookup', function(assert) {
+  let template = {};
+  let component = {};
+  let componentTemplate = {};
+  let resolver = this.resolverForEntries({
+    app: {
+      name: 'example-app'
+    },
+    types: {
+      component: { definitiveCollection: 'components' },
+      route: { definitiveCollection: 'routes' },
+      template: { definitiveCollection: 'components' }
+    },
+    collections: {
+      components: {
+        group: 'ui',
+        types: [ 'component', 'template' ]
+      },
+      routes: {
+        group: 'ui',
+        types: [ 'route', 'template' ]
+      }
+    }
+  }, {
+    'template:/app/components/my-post': template,
+    'template:/app/components/my-post/my-input': componentTemplate,
+    'component:/app/components/my-post/my-input': component
+  });
+
+  assert.equal(
+    resolver.resolve('template:my-input', 'template:/app/components/my-post'),
+    componentTemplate,
+    'relative template module specifier with source resolved'
+  );
+
+  assert.equal(
+    resolver.resolve('component:my-input', 'template:/app/components/my-post'),
+    component,
+    'relative component module specifier with source resolved'
+  );
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-resolver",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "The default modules based resolver for Ember CLI.",
   "directories": {
     "test": "tests"


### PR DESCRIPTION
@mixonic some improvements:
 - upgrade to ember-cli 2.13.0-beta.2
 - add tests
 - support location type
 - support optional type suffix (For example, for `service:auth`, we have to support both `my-app/src/services/auth.js` and `my-app/src/services/auth/service.js`)
 - expand local lookup*

*This is likely not the final implementation for expand local lookup but it works and it seems appropriate to add this now with tests to support it so that we can demo local lookup working in an app and then refactor later once the changes land in ember. Ember as it stands now calls `expandLocalLookup` anyway.